### PR TITLE
fix splitting of cache-control header value

### DIFF
--- a/lib/eu.js
+++ b/lib/eu.js
@@ -64,7 +64,7 @@ module.exports = function Eu(cache) {
         var private = options.private;
         if ('cache-control' in res.headers) {
           // In case of Cache-Control: no-cache, cacheable should remain false.
-          var val = res.headers['cache-control'].replace(/\s/, '').split(',');
+          var val = res.headers['cache-control'].split(/\s*,\s*/);
           var cacheControl = {};
           val.forEach(function (dir) {
             var arr = dir.split('=');

--- a/test/eu_test.js
+++ b/test/eu_test.js
@@ -202,6 +202,29 @@ stores.forEach(function (store) {
         });
       });
     });
+    it('caches privately for Cache-Control: max-age=300, no-transform, private', function (cb) {
+      http.createServer(function (req, res) {
+        var date = new Date().toUTCString();
+        res.writeHead(200, { 'Date': date, 'Cache-Control': 'max-age=300, no-transform, private' });
+        res.end('Cachifiable!');
+      }).listen(++port, function () {
+        var eu = new Eu(paulsCache);
+        eu.get('http://localhost:' + port, {}, function (err, res) {
+          if (err) return cb(err);
+          paulsCache.get('http://localhost:' + port, function (err, val) {
+            if (err) return cb(err);
+            assert.equal(val.response.body, 'Cachifiable!');
+            lisasCache.get('http://localhost:' + port, function (err, val) {
+              if (err) return cb(err);
+              assert.equal(val, undefined);
+              cb();
+            });
+          });
+        });
+      });
+    });
+
+
   });
 
 });


### PR DESCRIPTION
The splitting of the cache-control header value is incorrect, only stripping the first space character before splitting on commas. As a result, cache-control header values like this:

`cache-control: private, must-revalidate, max-age=0`

results in cache-directive with spaces in their names:

`{'private': true, 'must-revalidate': true, ' max-age': '0'}`

which prevents correct interpretation of the response.
