### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,13 @@
   "author": "Cucumber Limited",
   "license": "MIT/X11",
   "dependencies": {
-    "debug": "^2.1.2",
-    "request": "^2.53.0",
-    "request-debug": "^0.1.1"
+    "debug": "^2.2.0",
+    "request": "^2.74.0",
+    "request-debug": "^0.2.0"
   },
   "devDependencies": {
-    "mocha": "^2.1.0",
-    "lru-cache": "^2.5.0",
-    "redis": "^0.12.1",
-    "hiredis": "^0.2.0"
+    "mocha": "^2.5.3",
+    "lru-cache": "^4.0.1",
+    "redis": "^2.6.2"
   }
 }


### PR DESCRIPTION
`hiredis` is dropped since the maintainer of [node_redis](https://github.com/NodeRedis/node_redis) recommends using the JS parser instead of `hiredis` as [it performs better](https://github.com/NodeRedis/node_redis/blob/master/changelog.md#v260---01-jun-2016) starting v2.6.0.
